### PR TITLE
Add CloudWatch read policy to Optima

### DIFF
--- a/optima/formacloud_optima.yaml
+++ b/optima/formacloud_optima.yaml
@@ -92,6 +92,16 @@ Resources:
             StringEquals: 
               sts:ExternalId: !Ref FormaCloudExternalID
       Policies:
+      - PolicyName: FormaCloudCloudWatchMetricReadPolicy
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+          - Effect: Allow
+            Action:
+            - cloudwatch:Describe*
+            - cloudwatch:Get*
+            - cloudwatch:List*
+            Resource: "*"
       - PolicyName: FormaCloudBillingReadPolicy
         PolicyDocument:
           Version: 2012-10-17


### PR DESCRIPTION
With this policy, the Optima role is a superset of the ClariSpend role.