### PR TITLE
Support for single account installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ export AWS_SECRET_ACCESS_KEY=xxx
 export AWS_SESSION_TOKEN=xxx
 ```
 
-4. [AWS Organization](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tutorials_basic.html) enabled (recommend).
-5. Trusted access with AWS Organizations enabled (recommend):
+4. [AWS Organization](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tutorials_basic.html) enabled (recommended).
+5. Trusted access with AWS Organizations enabled (recommended):
 Sign in to AWS as an administrator of the management account and open the AWS CloudFormation console at https://console.aws.amazon.com/.
 From the navigation pane, choose StackSets. If trusted access is disabled, a banner displays that prompts you to enable trusted access.
 ![image](https://github.com/forma-cloud/FormaCloud/assets/117554189/ce841f64-3794-4dc2-b765-49d700cfff65)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/Forma
 Enter the region name where the stacks will be created;
 Choose whether you want to install it for the whole organization;
 Enter a list of regions where you want to enable Optima SavingBot;
-Enter whether you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts;
+Choose whether you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts;
 
 Sample output:
 
@@ -124,7 +124,7 @@ Sample output:
 Enter the region where the stacks will be created (e.g. us-west-2): us-east-1
 Do you want to install it for the whole organization (Y/N)? y
 Enter a list of regions where you want to enable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
-Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (true or false. [false]): 
+Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (Y/N) n 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  3047  100  3047    0     0   3210      0 --:--:-- --:--:-- --:--:--  3217

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ export AWS_SECRET_ACCESS_KEY=xxx
 export AWS_SESSION_TOKEN=xxx
 ```
 
-4. Trusted access with AWS Organizations enabled:
+4. [AWS Organization](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_tutorials_basic.html) enabled (recommend).
+5. Trusted access with AWS Organizations enabled (recommend):
 Sign in to AWS as an administrator of the management account and open the AWS CloudFormation console at https://console.aws.amazon.com/.
 From the navigation pane, choose StackSets. If trusted access is disabled, a banner displays that prompts you to enable trusted access.
 ![image](https://github.com/forma-cloud/FormaCloud/assets/117554189/ce841f64-3794-4dc2-b765-49d700cfff65)
@@ -42,12 +43,14 @@ export FORMACLOUD_EXTERNALID=xxx  # The external ID that authenticates your acco
 ```bash
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/install.sh)"
 ```
-Enter the region name where the stacks will be created.
+Enter the region name where the stacks will be created;
+Choose whether you want to install it for the whole organization;
 
 Sample output:
 
 ```
 Enter the region where the stacks will be created (e.g. us-west-2): us-west-2
+Do you want to install it for the whole organization (Y/N)? y
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
 100  3047  100  3047    0     0   3210      0 --:--:-- --:--:-- --:--:--  3217
@@ -62,6 +65,7 @@ Creating StackSet instances for the member accounts...
 Waiting for the above operation to finish..................
 Operation finished:
 FormaCloudClariSpend StackSet instances created!
+Installation completed.
 ```
 
 3. To uninstall ClariSpend, run the following command:
@@ -70,12 +74,14 @@ FormaCloudClariSpend StackSet instances created!
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/uninstall.sh)"
 ```
 
-Enter the region name where the stacks will be deleted.
+Enter the region name where the stacks will be deleted;
+Choose whether you want to uninstall it for the whole organization;
 
 Sample output:
 
 ```
 Enter the region where the stacks will be deleted (e.g. us-west-2): us-west-2
+Do you want to uninstall it for the whole organization (Y/N)? y
 Deleting the StackSet instances for the member accounts...
 ...
 Waiting for the above operation to finish...
@@ -83,9 +89,10 @@ Operation finished:
 ...
 FormaCloudClariSpend StackSet instances deleted!
 Deleting the StackSet...
-FormaCloudClariSpend StackSet Deleted!
+FormaCloudClariSpend StackSet deleted!
 Deleting the Stack...
 FormaCloudClariSpend Stack deleted!
+Uninstallation completed.
 ```
 
 ## Optima
@@ -107,13 +114,15 @@ $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/Forma
 ```
 
 Enter the region name where the stacks will be created;
+Choose whether you want to install it for the whole organization;
 Enter a list of regions where you want to enable Optima SavingBot;
-Enter whether you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts.
+Enter whether you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts;
 
 Sample output:
 
 ```
 Enter the region where the stacks will be created (e.g. us-west-2): us-east-1
+Do you want to install it for the whole organization (Y/N)? y
 Enter a list of regions where you want to enable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (true or false. [false]): 
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
@@ -130,6 +139,7 @@ Creating StackSet instances for the member accounts...
 Waiting for the above operation to finish..................
 Operation finished:
 FormaCloudOptima StackSet instances created!
+Installation completed.
 ```
 
 If you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts, please contact FormaCloud support to add FORMACLOUD_PRINCIPAL to the trust relationship of the role.
@@ -140,14 +150,16 @@ If you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/optima/uninstall.sh)"
 ```
 
-Enter the region where the stacks will be deleted (e.g. us-west-2): us-east-1
-Enter a list of regions where you want to disable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
+Enter the region name where the stacks will be deleted;
+Choose whether you want to uninstall it for the whole organization;
+Enter a list of regions where you want to disable Optima SavingBot;
 
 Sample output:
 
 ```
-Enter the region where the stacks will be created (e.g. us-west-2): us-east-1
-Enter a list of regions where you want to enable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
+Enter the region where the stacks will be deleted (e.g. us-west-2): us-east-1
+Do you want to uninstall it for the whole organization (Y/N)? y
+Enter a list of regions where you want to disable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Deleting the StackSet instances for the member accounts...
 ...
 Waiting for the above operation to finish...
@@ -155,9 +167,10 @@ Operation finished:
 ...
 FormaCloudOptima StackSet instances deleted!
 Deleting the StackSet...
-FormaCloudOptima StackSet Deleted!
+FormaCloudOptima StackSet deleted!
 Deleting the Stack...
 FormaCloudOptima Stack deleted!
+Uninstallation completed.
 ```
 
 ## Slack Integration

--- a/clarispend/install.sh
+++ b/clarispend/install.sh
@@ -50,9 +50,8 @@ else
 fi
 
 tmp_dir=$(mktemp -d)
-# tmp_file=${tmp_dir}/formacloud_clarispend.yaml
-# curl -o ${tmp_file} https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/formacloud_clarispend.yaml
-tmp_file=formacloud_clarispend.yaml
+tmp_file=${tmp_dir}/formacloud_clarispend.yaml
+curl -o ${tmp_file} https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/formacloud_clarispend.yaml
 
 echo "Creating a Stack..."
 aws cloudformation create-stack \

--- a/clarispend/install.sh
+++ b/clarispend/install.sh
@@ -28,23 +28,31 @@ function stackSetOperationWait {
 }
 
 stack_name=FormaCloudClariSpend
-root_account_id=$(aws organizations describe-organization | jq -r .Organization.MasterAccountId)
-org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
 
 test -n "$FORMACLOUD_ID" || die "FORMACLOUD_ID must be provided. Please contact FormaCloud support."
 test -n "$FORMACLOUD_PRINCIPAL" || die "FORMACLOUD_PRINCIPAL must be provided. Please contact FormaCloud support."
 test -n "$FORMACLOUD_EXTERNALID" || die "FORMACLOUD_EXTERNALID must be provided. Please contact FormaCloud support."
-test -n "$root_account_id" || die "AWS root account id not found."
-test -n "$org_id" || die "AWS root organization id not found."
 
 read -p "Enter the region where the stacks will be created (e.g. us-west-2): " main_region
 test -n "$main_region" || die "Invalid input: please specify a region"
 
 formacloud_pingback_arn=arn:aws:sns:${main_region}:${FORMACLOUD_PRINCIPAL}:formacloud-pingback-topic
 
+read -p "Do you want to install it for the whole organization (Y/N)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  root_account_id=$(aws organizations describe-organization | jq -r .Organization.MasterAccountId)
+  single_account=false
+else
+  root_account_id=$(aws sts get-caller-identity --query "Account" --output text)
+  single_account=true
+fi
+
 tmp_dir=$(mktemp -d)
-tmp_file=${tmp_dir}/formacloud_clarispend.yaml
-curl -o ${tmp_file} https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/formacloud_clarispend.yaml
+# tmp_file=${tmp_dir}/formacloud_clarispend.yaml
+# curl -o ${tmp_file} https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/clarispend/formacloud_clarispend.yaml
+tmp_file=formacloud_clarispend.yaml
 
 echo "Creating a Stack..."
 aws cloudformation create-stack \
@@ -59,6 +67,13 @@ ParameterKey=FormaCloudService,ParameterValue=${FORMACLOUD_SERVICE} \
 ParameterKey=FormaCloudPingbackArn,ParameterValue=${formacloud_pingback_arn} \
 ParameterKey=RootAccountID,ParameterValue=${root_account_id}
 echo "${stack_name} Stack created!"
+
+if [ ${single_account} = true ] ; then
+  echo "Installation completed."
+  exit 1
+fi
+
+org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
 
 echo "Creating a StackSet..."
 aws cloudformation create-stack-set \
@@ -88,3 +103,4 @@ stackSetOperationWait ${main_region} ${stack_name} ${operation_id}
 echo "${stack_name} StackSet instances created!"
 
 rm -r ${tmp_dir}
+echo "Installation completed."

--- a/clarispend/uninstall.sh
+++ b/clarispend/uninstall.sh
@@ -27,32 +27,34 @@ function stackSetOperationWait {
 }
 
 stack_name=FormaCloudClariSpend
-root_account_id=$(aws organizations describe-organization | jq -r .Organization.MasterAccountId)
-org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
-
-test -n "$root_account_id" || die "AWS root account id not found."
-test -n "$org_id" || die "AWS root organization id not found."
 
 read -p "Enter the region where the stacks will be deleted (e.g. us-west-2): " main_region
 test -n "$main_region" || die "Invalid input: please specify a region"
 
-echo "Deleting the StackSet instances for the member accounts..."
-operation_id="$(aws cloudformation delete-stack-instances \
---region ${main_region} \
---stack-set-name ${stack_name} \
---regions ${main_region} \
---no-retain-stacks \
---deployment-targets OrganizationalUnitIds=${org_id} \
---operation-preferences RegionConcurrencyType=PARALLEL,MaxConcurrentPercentage=100,FailureTolerancePercentage=100 \
---output text)"
-stackSetOperationWait ${main_region} ${stack_name} ${operation_id}
-echo "${stack_name} StackSet instances deleted!"
+read -p "Do you want to uninstall it for the whole organization (Y/N)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
 
-echo "Deleting the StackSet..."
-aws cloudformation delete-stack-set \
---region ${main_region} \
---stack-set-name ${stack_name}
-echo "${stack_name} StackSet Deleted!"
+  echo "Deleting the StackSet instances for the member accounts..."
+  operation_id="$(aws cloudformation delete-stack-instances \
+  --region ${main_region} \
+  --stack-set-name ${stack_name} \
+  --regions ${main_region} \
+  --no-retain-stacks \
+  --deployment-targets OrganizationalUnitIds=${org_id} \
+  --operation-preferences RegionConcurrencyType=PARALLEL,MaxConcurrentPercentage=100,FailureTolerancePercentage=100 \
+  --output text)"
+  stackSetOperationWait ${main_region} ${stack_name} ${operation_id}
+  echo "${stack_name} StackSet instances deleted!"
+
+  echo "Deleting the StackSet..."
+  aws cloudformation delete-stack-set \
+  --region ${main_region} \
+  --stack-set-name ${stack_name}
+  echo "${stack_name} StackSet deleted!"
+fi
 
 echo "Deleting the Stack..."
 aws cloudformation delete-stack \

--- a/clarispend/uninstall.sh
+++ b/clarispend/uninstall.sh
@@ -61,3 +61,4 @@ aws cloudformation delete-stack \
 --region ${main_region} \
 --stack-name ${stack_name}
 echo "${stack_name} Stack deleted!"
+echo "Uninstallation completed."

--- a/optima/install.sh
+++ b/optima/install.sh
@@ -50,7 +50,7 @@ else
   single_account=true
 fi
 
-read -p "Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (Y/N)" -n 1 -r
+read -p "Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (Y/N) " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]
 then

--- a/optima/uninstall.sh
+++ b/optima/uninstall.sh
@@ -26,36 +26,38 @@ function stackSetOperationWait {
   fi
 }
 
+stack_name=FormaCloudOptima
+
 read -p "Enter the region where the stacks will be deleted (e.g. us-west-2): " main_region
 test -n "$main_region" || die "Invalid input: please specify a region where the stacks will be deleted"
 
-read -p "Enter a list of regions where you want to disable Optima SavingBot (e.g. us-west-2 us-east-1): " regions
-test -n "$regions" || die "Invalid input: please specify a list of regions where you want to disable Optima SavingBot"
+read -p "Do you want to uninstall it for the whole organization (Y/N)? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+  org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
 
-stack_name=FormaCloudOptima
-root_account_id=$(aws organizations describe-organization | jq -r .Organization.MasterAccountId)
-org_id=$(aws organizations list-roots | jq -r .Roots[0].Id)
+  read -p "Enter a list of regions where you want to disable Optima SavingBot (e.g. us-west-2 us-east-1): " regions
+  test -n "$regions" || die "Invalid input: please specify a list of regions where you want to disable Optima SavingBot"
 
-test -n "$root_account_id" || die "AWS root account id not found."
-test -n "$org_id" || die "AWS root organization id not found."
+  echo "Deleting the StackSet instances for the member accounts..."
+  operation_id="$(aws cloudformation delete-stack-instances \
+  --region ${main_region} \
+  --stack-set-name ${stack_name} \
+  --regions ${regions} \
+  --no-retain-stacks \
+  --deployment-targets OrganizationalUnitIds=${org_id} \
+  --operation-preferences RegionConcurrencyType=PARALLEL,MaxConcurrentPercentage=100,FailureTolerancePercentage=100 \
+  --output text)"
+  stackSetOperationWait ${main_region} ${stack_name} ${operation_id}
+  echo "${stack_name} StackSet instances deleted!"
 
-echo "Deleting the StackSet instances for the member accounts..."
-operation_id="$(aws cloudformation delete-stack-instances \
---region ${main_region} \
---stack-set-name ${stack_name} \
---regions ${regions} \
---no-retain-stacks \
---deployment-targets OrganizationalUnitIds=${org_id} \
---operation-preferences RegionConcurrencyType=PARALLEL,MaxConcurrentPercentage=100,FailureTolerancePercentage=100 \
---output text)"
-stackSetOperationWait ${main_region} ${stack_name} ${operation_id}
-echo "${stack_name} StackSet instances deleted!"
-
-echo "Deleting the StackSet..."
-aws cloudformation delete-stack-set \
---region ${main_region} \
---stack-set-name ${stack_name}
-echo "${stack_name} StackSet Deleted!"
+  echo "Deleting the StackSet..."
+  aws cloudformation delete-stack-set \
+  --region ${main_region} \
+  --stack-set-name ${stack_name}
+  echo "${stack_name} StackSet deleted!"
+fi
 
 echo "Deleting the Stack..."
 aws cloudformation delete-stack \

--- a/optima/uninstall.sh
+++ b/optima/uninstall.sh
@@ -64,3 +64,4 @@ aws cloudformation delete-stack \
 --region ${main_region} \
 --stack-name ${stack_name}
 echo "${stack_name} Stack deleted!"
+echo "Uninstallation completed."


### PR DESCRIPTION
1. Added the step to create AWS organization to the prerequisites

2. Added a prompt: "Do you want to install/uninstall it for the whole organization (Y/N)?"
If the input is not y or Y, it will be only installed/uninstalled in a single account.

## Single account example:
```
Enter the region where the stacks will be created (e.g. us-west-2): us-west-2
Do you want to install it for the whole organization (Y/N)? n
Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (Y/N) n
Creating a Stack...
...
FormaCloudOptima Stack created!
Installation completed.
```

```
Enter the region where the stacks will be deleted (e.g. us-west-2): us-west-2
Do you want to uninstall it for the whole organization (Y/N)? n
Deleting the Stack...
FormaCloudOptima Stack deleted!
Uninstallation completed.
```

## Multi-account example
```
Enter the region where the stacks will be created (e.g. us-west-2): us-west-2
Do you want to install it for the whole organization (Y/N)? y
Creating a Stack...
...
FormaCloudClariSpend Stack created!
Creating a StackSet...
...
FormaCloudClariSpend StackSet created!
Creating StackSet instances for the member accounts...
...
Waiting for the above operation to finish..................
Operation finished:
...
FormaCloudClariSpend StackSet instances created!
Installation completed.
```

```
Enter the region where the stacks will be deleted (e.g. us-west-2): us-west-2
Do you want to uninstall it for the whole organization (Y/N)? y
Deleting the StackSet instances for the member accounts...
...
Waiting for the above operation to finish..................
Operation finished:
...
FormaCloudClariSpend StackSet instances deleted!
Deleting the StackSet...
FormaCloudClariSpend StackSet Deleted!
Deleting the Stack...
FormaCloudClariSpend Stack deleted!
```