### PR TITLE
Optima multi-region support in the root account

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,21 +51,21 @@ export FORMACLOUD_EVENT_BUS_ARN=xxx  # The EventBus to receive EC2 instance even
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/optima/install.sh)"
 ```
 
-Enter the region name where the stacks will be created;
+Enter a list of regions where you want to enable Optima. The first one will be used as the main region to create IAM role related resources;
 Choose whether you want to install it for the whole organization;
-Enter a list of regions where you want to enable Optima SavingBot;
 Choose whether you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts;
 
 Sample output:
 
 ```
-Enter the region where the stacks will be created (e.g. us-west-2): us-east-1
+Enter a list of regions where you want to enable Optima (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Do you want to install it for the whole organization (Y/N)? y
-Enter a list of regions where you want to enable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Do you already have CloudWatch-CrossAccountSharingRole IAM role in your accounts? (Y/N) n 
-Creating a Stack...
+Creating a Stack in us-west-2...
 ...
-FormaCloudOptima Stack created!
+Creating a Stack in us-east-1...
+...
+FormaCloudOptima Stacks created!
 Creating a StackSet...
 ...
 FormaCloudOptima StackSet created!
@@ -163,16 +163,14 @@ To uninstall Optima, run the following command:
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/forma-cloud/FormaCloud/main/optima/uninstall.sh)"
 ```
 
-Enter the region name where the stacks will be deleted;
+Enter a list of regions where you want to disable Optima.
 Choose whether you want to uninstall it for the whole organization;
-Enter a list of regions where you want to disable Optima SavingBot;
 
 Sample output:
 
 ```
-Enter the region where the stacks will be deleted (e.g. us-west-2): us-east-1
+Enter a list of regions where you want to disable Optima (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Do you want to uninstall it for the whole organization (Y/N)? y
-Enter a list of regions where you want to disable Optima SavingBot (e.g. us-west-2 us-east-1): us-west-2 us-east-1
 Deleting the StackSet instances for the member accounts...
 ...
 Waiting for the above operation to finish...
@@ -181,8 +179,9 @@ Operation finished:
 FormaCloudOptima StackSet instances deleted!
 Deleting the StackSet...
 FormaCloudOptima StackSet deleted!
-Deleting the Stack...
-FormaCloudOptima Stack deleted!
+Deleting the Stack in us-west-2...
+Deleting the Stack in us-east-1...
+FormaCloudOptima Stacks deleted!
 Uninstallation completed.
 ```
 

--- a/clarispend/formacloud_clarispend.yaml
+++ b/clarispend/formacloud_clarispend.yaml
@@ -93,11 +93,11 @@ Resources:
     Version: 1.0
     Properties:
       ServiceToken: !Ref FormaCloudPingbackArn
-      RootAccountID: !Ref RootAccountID
-      MainRegion: !Ref AWS::Region
       FormaCloudID: !Ref FormaCloudID
       FormaCloudService: !Ref FormaCloudService
-      RoleArn: !GetAtt  FormaCloudClariSpendRole.Arn
+      AccountID: !Ref AWS::AccountId
+      RootAccountID: !Ref RootAccountID
+      MainRegion: !Ref AWS::Region
 Outputs:
   FormaCloudClariSpendRoleArn:
     Value: !GetAtt FormaCloudClariSpendRole.Arn

--- a/optima/formacloud_optima.yaml
+++ b/optima/formacloud_optima.yaml
@@ -29,6 +29,10 @@ Parameters:
     Description: Specify the main region where the IAM role related stacks will be created.
     MinLength: 1
     Type: String
+  Regions:
+    Description: Specify the regions that will be managed by Optima.
+    MinLength: 1
+    Type: String
   FormaCloudEventBusArn:
     Description: The EventBus to receive EC2 instance events.
     MinLength: 1
@@ -240,11 +244,12 @@ Resources:
     Version: 1.0
     Properties:
       ServiceToken: !Ref FormaCloudPingbackArn
-      RootAccountID: !Ref RootAccountID
-      MainRegion: !Ref AWS::Region
       FormaCloudID: !Ref FormaCloudID
       FormaCloudService: !Ref FormaCloudService
-      RoleArn: !GetAtt  FormaCloudOptimaRole.Arn
+      AccountID: !Ref AWS::AccountId
+      RootAccountID: !Ref RootAccountID
+      MainRegion: !Ref AWS::Region
+      Regions: !Ref Regions
 Outputs:
   FormaCloudOptimaRoleArn:
     Condition: RegionCheck


### PR DESCRIPTION
1. To enable SavingBot in multiple regions in the root account, multiple stacks need to be created in each region.
2. Added account id and regions to the pingback.